### PR TITLE
Feature/semver

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "homepage": "https://github.com/paulocaldeira17/angular-websql",
   "dependencies": {
-    "angular": "1.2.x"
+    "angular": ">=1.2.0 <1.5.0"
   },
   "ignore": [
     "**/.*",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "angular-websql",
-  "version": "1.0.1",
   "description": "Helps you generating websql simple queries without writing any sql code.",
   "author": "Paulo Caldeira",
   "main": "./angular-websql.min.js",


### PR DESCRIPTION
Hi,

Since `version` is now a depreciated attribute I removed it.

Testing has proved (for me at least) that this module works in Angular 1.4.4 so I figured it might as well allow installing in to that version.

Would you mind merging this and incrementing the tag to 1.0.3?

Many thanks,


Andy

PS. I have been using this in the following repo: https://github.com/atwright147/angular-todo/tree/feature/browser-db